### PR TITLE
Add support for ASP server-side comments

### DIFF
--- a/Syntaxes/HTML-ASP.plist
+++ b/Syntaxes/HTML-ASP.plist
@@ -14,6 +14,35 @@
 	<array>
 		<dict>
 			<key>begin</key>
+			<string>&lt;%--</string>
+			<key>captures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.html</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>--%&gt;</string>
+			<key>name</key>
+			<string>comment.block.asp.server</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>--</string>
+					<key>name</key>
+					<string>invalid.illegal.bad-comments-or-CDATA.html</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#embedded-code</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>&lt;%=?</string>
 			<key>beginCaptures</key>
 			<dict>


### PR DESCRIPTION
[Originally reported as an issue with GitHub's linguist](https://github.com/github/linguist/issues/895), I found that the problem was actually with the HTML-ASP textmate bundle that GitHub's Linguist uses for syntax highlighting.

Previously, the highlighting would [miss the server-side comments](https://lightshow.githubapp.com/?utf8=✓&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Ftextmate%2Fasp.tmbundle%2Fmaster%2FSyntaxes%2FHTML-ASP.plist&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fabitgone%2Flinguist-aspx-comments%2Fmaster%2Ftest.aspx&code=).

I've added a pattern which detects the <%-- --%> syntax used for ASP server-side comments (as used in ASP and ASP.NET), and [Lightshow now detects the comments correctly](https://lightshow.githubapp.com/?utf8=✓&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fabitgone%2Fasp.tmbundle%2Fmaster%2FSyntaxes%2FHTML-ASP.plist&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fabitgone%2Flinguist-aspx-comments%2Fmaster%2Ftest.aspx&code=) – as does TextMate, Sublime Text and any other applications which rely on this grammar.
